### PR TITLE
内部リソース操作用の IAM グループを追加

### DIFF
--- a/.tfsec/config.yml
+++ b/.tfsec/config.yml
@@ -3,3 +3,4 @@ min_required_version: v1.28.1
 exclude:
   - aws-s3-enable-bucket-logging
   - aws-s3-encryption-customer-key
+  - aws-iam-enforce-group-mfa

--- a/modules/identity/iam.tf
+++ b/modules/identity/iam.tf
@@ -60,3 +60,36 @@ data "aws_iam_policy_document" "ci_policy" {
     ]
   }
 }
+
+resource "aws_iam_group" "internal_resource_controller" {
+  name = "${var.app_name}-internal-resource-controller"
+  path = "/"
+}
+
+resource "aws_iam_group_policy_attachment" "internal_resource_controller" {
+  group      = aws_iam_group.internal_resource_controller.name
+  policy_arn = aws_iam_policy.internal_resource_controller_policy.arn
+}
+
+resource "aws_iam_policy" "internal_resource_controller_policy" {
+  name        = "${aws_iam_group.internal_resource_controller.name}-policy"
+  description = "for Internal Resource Controller"
+
+  policy = data.aws_iam_policy_document.internal_resource_controller_policy.json
+}
+
+data "aws_iam_policy_document" "internal_resource_controller_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.internal_resource_bucket}/*",
+    ]
+  }
+}


### PR DESCRIPTION
- アクセスキーの発行などの対応も必要なので、ユーザーは個別管理する